### PR TITLE
Fix: Hinzufügen expliziter Workflow-Berechtigungen

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,8 @@
 name: CD
 
+permissions:
+  contents: write  # Für git tag und git push operations
+
 on:
   push:
     branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read  # Nur Leserechte für CI-Tests
+
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
## Beschreibung

Dieser PR behebt den Security-Alert "actions/missing-workflow-permissions" durch Hinzufügen expliziter Berechtigungen zu den GitHub Actions Workflows.

### Änderungen

1. `.github/workflows/cd.yml`: 
   - Hinzugefügt `permissions: contents: write` - notwendig für Git-Operationen wie Tags erstellen, Branches mergen und Pushen.

2. `.github/workflows/ci.yml`: 
   - Hinzugefügt `permissions: contents: read` - minimale Rechte für CI-Tests, die nur Zugriff auf Repository-Inhalte benötigen.

Diese Änderungen folgen dem Prinzip der geringsten Privilegien und verbessern die Sicherheit der Workflows.

## Gelöste Issues

Behebt den Security-Alert #2
