### PR TITLE
ci: Go 1.26 (Workflows + go.mod)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        go-version: [ '1.25' ]
+        go-version: [ '1.26' ]
     steps:
       - uses: actions/checkout@v6
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Talk-Point/go-webtoolkit
 
-go 1.25.8
+go 1.26
 
 require (
 	cloud.google.com/go/cloudtasks v1.18.0


### PR DESCRIPTION
Hebt die Go-Version auf 1.26 an: `go-version` in den Actions-Workflows und die `go`-Direktive in jeder go.mod (`toolchain`-Pin entfernt). Kein `go mod tidy`. Org-weite Angleichung, Tracking: Talk-Point/IT#15822.